### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/323/35/85632335.geojson
+++ b/data/856/323/35/85632335.geojson
@@ -899,6 +899,10 @@
     },
     "wof:country":"GD",
     "wof:country_alpha3":"GRD",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"5c1a4a4402df2bc35da06c2ab16c48bd",
     "wof:hierarchy":[
         {
@@ -913,7 +917,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566636673,
+    "wof:lastmodified":1582343573,
     "wof:name":"Grenada",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/890/451/719/890451719.geojson
+++ b/data/890/451/719/890451719.geojson
@@ -453,6 +453,9 @@
     },
     "wof:country":"GD",
     "wof:created":1469052791,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"457986e3d1b4fc93fe89c9e4e02d1be2",
     "wof:hierarchy":[
         {
@@ -461,7 +464,7 @@
         }
     ],
     "wof:id":890451719,
-    "wof:lastmodified":1566636698,
+    "wof:lastmodified":1582343573,
     "wof:name":"Saint George's",
     "wof:parent_id":-1,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.