### PR TITLE
Name updates

### DIFF
--- a/data/856/323/35/85632335.geojson
+++ b/data/856/323/35/85632335.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030817,
-    "geom:area_square_m":372520502.529897,
+    "geom:area_square_m":372520246.528007,
     "geom:bbox":"-61.805889,11.983,-61.378834,12.537861",
     "geom:latitude":12.155005,
     "geom:longitude":-61.659759,
@@ -44,6 +44,9 @@
     "name:amh_x_variant":[
         "\u130d\u122c\u1293\u12f3"
     ],
+    "name:ang_x_preferred":[
+        "Gren\u0113da"
+    ],
     "name:ara_x_preferred":[
         "\u063a\u0631\u064a\u0646\u0627\u062f\u0627"
     ],
@@ -52,6 +55,9 @@
     ],
     "name:arg_x_preferred":[
         "Grenada"
+    ],
+    "name:ary_x_preferred":[
+        "\u06ad\u0631\u064a\u0646\u0627\u062f\u0627"
     ],
     "name:arz_x_preferred":[
         "\u062c\u0631\u064a\u0646\u0627\u062f\u0627"
@@ -147,6 +153,12 @@
     "name:dan_x_preferred":[
         "Grenada"
     ],
+    "name:deu_at_x_preferred":[
+        "Grenada"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Grenada"
+    ],
     "name:deu_x_preferred":[
         "Grenada"
     ],
@@ -164,6 +176,12 @@
     ],
     "name:ell_x_preferred":[
         "\u0393\u03c1\u03b5\u03bd\u03ac\u03b4\u03b1"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Grenada"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Grenada"
     ],
     "name:eng_x_preferred":[
         "Grenada"
@@ -231,6 +249,9 @@
     ],
     "name:gag_x_preferred":[
         "Grenada"
+    ],
+    "name:gcr_x_preferred":[
+        "Gr\u00e9nad"
     ],
     "name:gla_x_preferred":[
         "Greanada"
@@ -540,6 +561,9 @@
     "name:pol_x_preferred":[
         "Grenada"
     ],
+    "name:por_br_x_preferred":[
+        "Granada"
+    ],
     "name:por_x_preferred":[
         "Granada",
         "Granada (pa\u00eds)"
@@ -601,8 +625,14 @@
     "name:sme_x_preferred":[
         "Grenada"
     ],
+    "name:smo_x_preferred":[
+        "Grenada"
+    ],
     "name:sna_x_preferred":[
         "Grenada"
+    ],
+    "name:snd_x_preferred":[
+        "\u06af\u0631\u064a\u0646\u0627\u068a\u0627"
     ],
     "name:som_x_preferred":[
         "Giriinaada"
@@ -618,6 +648,12 @@
         "Grenada"
     ],
     "name:srd_x_preferred":[
+        "Grenada"
+    ],
+    "name:srp_ec_x_preferred":[
+        "\u0413\u0440\u0435\u043d\u0430\u0434\u0430"
+    ],
+    "name:srp_el_x_preferred":[
         "Grenada"
     ],
     "name:srp_x_preferred":[
@@ -682,6 +718,9 @@
     ],
     "name:tur_x_variant":[
         "Granada"
+    ],
+    "name:udm_x_preferred":[
+        "\u0413\u0440\u0435\u043d\u0430\u0434\u0430"
     ],
     "name:uig_x_preferred":[
         "\u06af\u0631\u06d0\u0646\u0627\u062f\u0627"
@@ -755,8 +794,23 @@
     "name:zha_x_preferred":[
         "Gwzlinznazdaz"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u683c\u6797\u7eb3\u8fbe"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u683c\u6797\u7d0d\u9054"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Grenada"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u683c\u6797\u7d0d\u9054"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u683c\u6797\u7eb3\u8fbe"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u683c\u745e\u90a3\u9054"
     ],
     "name:zho_x_preferred":[
         "\u683c\u6797\u7eb3\u8fbe"
@@ -918,7 +972,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1583797344,
+    "wof:lastmodified":1587427294,
     "wof:name":"Grenada",
     "wof:parent_id":102191575,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.