### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/596/328/1/1125963281.geojson
+++ b/data/112/596/328/1/1125963281.geojson
@@ -43,6 +43,9 @@
     "name:hye_x_preferred":[
         "\u054e\u056b\u056f\u057f\u0578\u0580\u056b\u0561"
     ],
+    "name:ita_x_preferred":[
+        "Victoria"
+    ],
     "name:jpn_x_preferred":[
         "\u30d3\u30af\u30c8\u30ea\u30a2"
     ],
@@ -54,6 +57,9 @@
     ],
     "name:pol_x_preferred":[
         "Victoria"
+    ],
+    "name:rus_x_preferred":[
+        "\u0412\u0438\u043a\u0442\u043e\u0440\u0438\u044f"
     ],
     "name:swe_x_preferred":[
         "Victoria"
@@ -117,7 +123,7 @@
         }
     ],
     "wof:id":1125963281,
-    "wof:lastmodified":1636500405,
+    "wof:lastmodified":1690921369,
     "wof:name":"Victoria",
     "wof:parent_id":85671627,
     "wof:placetype":"locality",

--- a/data/112/596/329/9/1125963299.geojson
+++ b/data/112/596/329/9/1125963299.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Sauteurs"
+    ],
     "name:bul_x_preferred":[
         "\u0421\u0430\u0443\u0442\u0435\u0443\u0440\u0441"
     ],
@@ -66,6 +69,9 @@
     ],
     "name:pol_x_preferred":[
         "Sauteurs"
+    ],
+    "name:rus_x_preferred":[
+        "\u0421\u0430\u0443\u0442\u0435\u0440\u0437"
     ],
     "name:spa_x_preferred":[
         "Sauteurs"
@@ -119,7 +125,7 @@
         }
     ],
     "wof:id":1125963299,
-    "wof:lastmodified":1566636699,
+    "wof:lastmodified":1690921369,
     "wof:name":"Sauteurs",
     "wof:parent_id":85671631,
     "wof:placetype":"locality",

--- a/data/421/169/441/421169441.geojson
+++ b/data/421/169/441/421169441.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-61.3939185,12.521049,-61.3939185,12.521049",
+    "geom:bbox":"-61.393918,12.521049,-61.393918,12.521049",
     "geom:latitude":12.521049,
     "geom:longitude":-61.393918,
     "iso:country":"GD",
@@ -35,10 +35,16 @@
     "name:ita_x_preferred":[
         "Meldrum"
     ],
+    "name:jpn_x_preferred":[
+        "\u30e1\u30eb\u30c9\u30e9\u30e0"
+    ],
     "name:nld_x_preferred":[
         "Meldrum"
     ],
     "name:sco_x_preferred":[
+        "Meldrum"
+    ],
+    "name:spa_x_preferred":[
         "Meldrum"
     ],
     "name:zho_x_preferred":[
@@ -75,7 +81,7 @@
     },
     "wof:country":"GD",
     "wof:created":1459008810,
-    "wof:geomhash":"e89815ad7103ff71a862f1d61671e96b",
+    "wof:geomhash":"5ef26fa2eb6270c618d16c91f57ba001",
     "wof:hierarchy":[
         {
             "country_id":85632335,
@@ -83,7 +89,7 @@
         }
     ],
     "wof:id":421169441,
-    "wof:lastmodified":1566636697,
+    "wof:lastmodified":1690921366,
     "wof:name":"Meldrum",
     "wof:parent_id":-1,
     "wof:placetype":"locality",
@@ -93,10 +99,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -61.3939185,
+    -61.393918,
     12.521049,
-    -61.3939185,
+    -61.393918,
     12.521049
 ],
-  "geometry": {"coordinates":[-61.3939185,12.521049],"type":"Point"}
+  "geometry": {"coordinates":[-61.393918,12.521049],"type":"Point"}
 }

--- a/data/856/323/35/85632335.geojson
+++ b/data/856/323/35/85632335.geojson
@@ -29,6 +29,9 @@
     "mz:is_current":1,
     "mz:max_zoom":9.0,
     "mz:min_zoom":4.0,
+    "name:abk_x_preferred":[
+        "\u0413\u0440\u0435\u043d\u0430\u0434\u0430"
+    ],
     "name:afr_x_preferred":[
         "Grenada"
     ],
@@ -46,6 +49,9 @@
     ],
     "name:ang_x_preferred":[
         "Gren\u0113da"
+    ],
+    "name:anp_x_preferred":[
+        "\u0917\u094d\u0930\u0947\u0928\u0947\u0921\u093e"
     ],
     "name:ara_x_preferred":[
         "\u063a\u0631\u064a\u0646\u0627\u062f\u0627"
@@ -82,6 +88,9 @@
     ],
     "name:bam_x_preferred":[
         "Granadi"
+    ],
+    "name:ban_x_preferred":[
+        "Gr\u00e9nada"
     ],
     "name:bar_x_preferred":[
         "Grenada"
@@ -148,6 +157,9 @@
         "Grenada"
     ],
     "name:cym_x_preferred":[
+        "Grenada"
+    ],
+    "name:dag_x_preferred":[
         "Grenada"
     ],
     "name:dan_x_preferred":[
@@ -247,6 +259,9 @@
     "name:ful_x_preferred":[
         "Garnaad"
     ],
+    "name:ful_x_variant":[
+        "Gerenaada"
+    ],
     "name:gag_x_preferred":[
         "Grenada"
     ],
@@ -275,6 +290,9 @@
     "name:gom_x_preferred":[
         "\u0917\u094d\u0930\u0947\u0928\u0947\u0921\u093e"
     ],
+    "name:gpe_x_preferred":[
+        "Grenada"
+    ],
     "name:grn_x_preferred":[
         "Gyran\u00e1ta"
     ],
@@ -292,6 +310,9 @@
     ],
     "name:hau_x_preferred":[
         "Girnada"
+    ],
+    "name:hau_x_variant":[
+        "Grenada"
     ],
     "name:hbs_x_preferred":[
         "Grenada"
@@ -368,6 +389,9 @@
     "name:kan_x_variant":[
         "\u0c97\u0ccd\u0cb0\u0cc6\u0ca8\u0cc6\u0ca1\u0cbe"
     ],
+    "name:kas_x_preferred":[
+        "\u06af\u064e\u0631\u0646\u06cc\u0691\u0627"
+    ],
     "name:kat_x_preferred":[
         "\u10d2\u10e0\u10d4\u10dc\u10d0\u10d3\u10d0"
     ],
@@ -425,6 +449,9 @@
     "name:lit_x_preferred":[
         "Grenada"
     ],
+    "name:lld_x_preferred":[
+        "Grenada"
+    ],
     "name:lmo_x_preferred":[
         "Grenada"
     ],
@@ -440,6 +467,9 @@
     "name:lzh_x_preferred":[
         "\u683c\u745e\u90a3\u9054"
     ],
+    "name:mad_x_preferred":[
+        "Grenada"
+    ],
     "name:mal_x_preferred":[
         "\u0d17\u0d4d\u0d30\u0d28\u0d47\u0d21"
     ],
@@ -449,11 +479,17 @@
     "name:mdf_x_preferred":[
         "\u0413\u0440\u0435\u043d\u0430\u0434\u0430"
     ],
+    "name:mdf_x_variant":[
+        "\u0413\u0440\u044d\u043d\u0430\u0434\u0430"
+    ],
     "name:mhr_x_preferred":[
         "\u0413\u0440\u0435\u043d\u0430\u0434\u0435"
     ],
     "name:mhr_x_variant":[
         "\u0413\u0440\u0435\u043d\u0430\u0434\u0430"
+    ],
+    "name:min_x_preferred":[
+        "Grenada"
     ],
     "name:mkd_x_preferred":[
         "\u0413\u0440\u0435\u043d\u0430\u0434\u0430"
@@ -464,8 +500,14 @@
     "name:mlt_x_preferred":[
         "Grenada"
     ],
+    "name:mni_x_preferred":[
+        "\uabd2\uabed\uabd4\uabe6\uabc5\uabe5\uabd7\uabe5"
+    ],
     "name:mon_x_preferred":[
         "\u0413\u0440\u0435\u043d\u0430\u0434 \u0443\u043b\u0441"
+    ],
+    "name:mri_x_preferred":[
+        "Keren\u0101ra"
     ],
     "name:msa_x_preferred":[
         "Grenada"
@@ -610,6 +652,9 @@
     "name:sgs_x_preferred":[
         "Grenada"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1075\u101b\u1084\u1087\u107c\u1083\u1087\u1010\u1083\u1087"
+    ],
     "name:sin_x_preferred":[
         "\u0d9c\u0dca\u200d\u0dbb\u0dd0\u0db1\u0da9\u0dcf\u0dc0"
     ],
@@ -625,7 +670,13 @@
     "name:sme_x_preferred":[
         "Grenada"
     ],
+    "name:smn_x_preferred":[
+        "Grenada"
+    ],
     "name:smo_x_preferred":[
+        "Grenada"
+    ],
+    "name:sms_x_preferred":[
         "Grenada"
     ],
     "name:sna_x_preferred":[
@@ -702,10 +753,14 @@
         "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e40\u0e01\u0e23\u0e40\u0e19\u0e14\u0e32"
     ],
     "name:tha_x_variant":[
-        "\u0e40\u0e01\u0e23\u0e40\u0e19\u0e14\u0e32"
+        "\u0e40\u0e01\u0e23\u0e40\u0e19\u0e14\u0e32",
+        "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e01\u0e23\u0e35\u0e40\u0e19\u0e14\u0e32"
     ],
     "name:tir_x_preferred":[
         "\u130d\u122c\u1293\u12f3"
+    ],
+    "name:tok_x_preferred":[
+        "ma Kenata"
     ],
     "name:ton_x_preferred":[
         "Kelenat\u0101"
@@ -1038,7 +1093,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500402,
+    "wof:lastmodified":1690921363,
     "wof:name":"Grenada",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/716/05/85671605.geojson
+++ b/data/856/716/05/85671605.geojson
@@ -76,11 +76,17 @@
     "name:fas_x_preferred":[
         "\u06a9\u0627\u0631\u06cc\u0627\u06a9\u0648 \u0648 \u067e\u062a\u06cc\u062a \u0645\u0627\u0631\u062a\u06cc\u0646\u06cc\u06a9\u0648"
     ],
+    "name:fas_x_variant":[
+        "\u067e\u0631\u06cc\u0634 \u0633\u0646\u062a \u067e\u0627\u062a\u0631\u06cc\u06a9"
+    ],
     "name:fin_x_preferred":[
         "Saint Patrick"
     ],
     "name:fra_x_preferred":[
         "Paroisse de Saint Patrick"
+    ],
+    "name:frr_x_preferred":[
+        "Saint Patrick"
     ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0aaa\u0ac7\u0a9f\u0acd\u0ab0\u0abf\u0a95 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
@@ -297,7 +303,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500402,
+    "wof:lastmodified":1690921363,
     "wof:name":"Carriacou and Petite Martinique",
     "wof:parent_id":85632335,
     "wof:placetype":"region",

--- a/data/856/716/09/85671609.geojson
+++ b/data/856/716/09/85671609.geojson
@@ -64,11 +64,17 @@
     "name:eus_x_preferred":[
         "Saint Andrew"
     ],
+    "name:fas_x_preferred":[
+        "\u067e\u0631\u06cc\u0634 \u0633\u0646\u062a \u0627\u0646\u062f\u0631\u0648"
+    ],
     "name:fin_x_preferred":[
         "Saint Andrew"
     ],
     "name:fra_x_preferred":[
         "Paroisse de Saint Andrew"
+    ],
+    "name:frr_x_preferred":[
+        "Saint Andrew"
     ],
     "name:glg_x_preferred":[
         "Saint Andrew"
@@ -94,11 +100,17 @@
     "name:jpn_x_preferred":[
         "\u30bb\u30f3\u30c8\u30fb\u30a2\u30f3\u30c9\u30ea\u30e5\u30fc\u30ba"
     ],
+    "name:jpn_x_variant":[
+        "\u30bb\u30f3\u30c8\u30fb\u30a2\u30f3\u30c9\u30ea\u30e5\u30fc\u6559\u533a"
+    ],
     "name:kan_x_preferred":[
         "\u0cb8\u0cc7\u0c82\u0c9f\u0ccd \u0c86\u0c82\u0ca1\u0ccd\u0cb0\u0ccd\u0caf\u0cc2 \u0caa\u0ccd\u0caf\u0cbe\u0cb0\u0cbf\u0cb7\u0ccd"
     ],
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\uc564\ub4dc\ub8e8 \uad50\uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\uc564\ub4dc\ub8e8\uad6c"
     ],
     "name:lav_x_preferred":[
         "Sentrendr\u016b pagasts"
@@ -118,6 +130,9 @@
     "name:nob_x_preferred":[
         "Saint Andrew prestegjeld"
     ],
+    "name:nob_x_variant":[
+        "Saint Andrew Parish"
+    ],
     "name:nor_x_preferred":[
         "Saint Andrew prestegjeld"
     ],
@@ -125,6 +140,9 @@
         "Saint Andrew"
     ],
     "name:por_x_preferred":[
+        "Saint Andrew"
+    ],
+    "name:ron_x_preferred":[
         "Saint Andrew"
     ],
     "name:rus_x_preferred":[
@@ -285,7 +303,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500403,
+    "wof:lastmodified":1690921365,
     "wof:name":"Saint Andrew",
     "wof:parent_id":85632335,
     "wof:placetype":"region",

--- a/data/856/716/13/85671613.geojson
+++ b/data/856/716/13/85671613.geojson
@@ -35,6 +35,9 @@
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u09a8\u09cd\u099f \u09a1\u09c7\u09ad\u09bf\u09a1 \u09aa\u09cd\u09af\u09be\u09b0\u09bf\u09b6"
     ],
+    "name:cat_x_preferred":[
+        "Saint David"
+    ],
     "name:ceb_x_preferred":[
         "Saint David"
     ],
@@ -64,11 +67,17 @@
     "name:eus_x_preferred":[
         "Saint David"
     ],
+    "name:fas_x_preferred":[
+        "\u067e\u0627\u0631\u06cc\u0633 \u0633\u0646\u062a \u062f\u06cc\u0648\u06cc\u062f"
+    ],
     "name:fin_x_preferred":[
         "Saint David"
     ],
     "name:fra_x_preferred":[
         "Paroisse de Saint David"
+    ],
+    "name:frr_x_preferred":[
+        "Saint David"
     ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0aa1\u0ac7\u0ab5\u0abf\u0aa1 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
@@ -91,11 +100,17 @@
     "name:jpn_x_preferred":[
         "\u30bb\u30f3\u30c8\u30fb\u30c7\u30a4\u30f4\u30a3\u30c3\u30c9\u90e1"
     ],
+    "name:jpn_x_variant":[
+        "\u30bb\u30f3\u30c8\u30fb\u30c7\u30a4\u30f4\u30a3\u30c3\u30c9\u6559\u533a"
+    ],
     "name:kan_x_preferred":[
         "\u0cb8\u0cc7\u0c82\u0c9f\u0ccd \u0ca1\u0cc7\u0cb5\u0cbf\u0ca1\u0ccd \u0caa\u0ccd\u0caf\u0cbe\u0cb0\u0cbf\u0cb7\u0ccd"
     ],
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\ub370\uc774\ube44\ub4dc \uad50\uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\ub370\uc774\ube44\ub4dc\uad6c"
     ],
     "name:lav_x_preferred":[
         "Sentdeivida pagasts"
@@ -114,6 +129,9 @@
     ],
     "name:nob_x_preferred":[
         "Saint David prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint David Parish"
     ],
     "name:nor_x_preferred":[
         "Saint David prestegjeld"
@@ -282,7 +300,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500403,
+    "wof:lastmodified":1690921365,
     "wof:name":"Saint David",
     "wof:parent_id":85632335,
     "wof:placetype":"region",

--- a/data/856/716/17/85671617.geojson
+++ b/data/856/716/17/85671617.geojson
@@ -32,6 +32,12 @@
     "name:ara_x_preferred":[
         "\u0623\u0628\u0631\u0634\u064a\u0629 \u0627\u0644\u0642\u062f\u064a\u0633 \u062c\u0648\u0631\u062c"
     ],
+    "name:aze_x_preferred":[
+        "Sent-Corc s\u0259mti"
+    ],
+    "name:bel_x_preferred":[
+        "\u041f\u0440\u044b\u0445\u043e\u0434 \u0421\u0435\u043d\u0442-\u0414\u0436\u043e\u0440\u0434\u0436"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u09a8\u09cd\u099f \u099c\u09b0\u09cd\u099c \u09aa\u09cd\u09af\u09be\u09b0\u09bf\u09b6"
     ],
@@ -67,11 +73,17 @@
     "name:fas_x_preferred":[
         "\u0633\u0646\u062a \u062c\u0648\u0631\u062c"
     ],
+    "name:fas_x_variant":[
+        "\u067e\u0631\u06cc\u0634 \u0633\u0646\u062a \u062c\u0648\u0631\u062c"
+    ],
     "name:fin_x_preferred":[
         "Saint George"
     ],
     "name:fra_x_preferred":[
         "Paroisse de Saint George"
+    ],
+    "name:frr_x_preferred":[
+        "Saint George"
     ],
     "name:glg_x_preferred":[
         "Saint George"
@@ -97,11 +109,17 @@
     "name:jpn_x_preferred":[
         "\u30bb\u30f3\u30c8\u30fb\u30b8\u30e7\u30fc\u30b8\u90e1"
     ],
+    "name:jpn_x_variant":[
+        "\u30bb\u30f3\u30c8\u30fb\u30b8\u30e7\u30fc\u30b8\u6559\u533a"
+    ],
     "name:kan_x_preferred":[
         "\u0cb8\u0cc7\u0c82\u0c9f\u0ccd \u0c9c\u0cbe\u0cb0\u0ccd\u0c9c\u0ccd \u0caa\u0ccd\u0caf\u0cbe\u0cb0\u0cbf\u0cb7\u0ccd"
     ],
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\uc870\uc9c0 \uad50\uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\uc870\uc9c0\uad6c"
     ],
     "name:lav_x_preferred":[
         "Sentd\u017eord\u017ea pagasts"
@@ -121,6 +139,9 @@
     "name:nob_x_preferred":[
         "Saint George prestegjeld"
     ],
+    "name:nob_x_variant":[
+        "Saint George Parish"
+    ],
     "name:nor_x_preferred":[
         "Saint George prestegjeld"
     ],
@@ -129,6 +150,9 @@
     ],
     "name:por_x_preferred":[
         "Saint George"
+    ],
+    "name:por_x_variant":[
+        "S\u00e3o Jorge"
     ],
     "name:rus_x_preferred":[
         "\u041f\u0440\u0438\u0445\u043e\u0434 \u0421\u0435\u043d\u0442-\u0414\u0436\u043e\u0440\u0434\u0436"
@@ -288,7 +312,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500403,
+    "wof:lastmodified":1690921364,
     "wof:name":"Saint George",
     "wof:parent_id":85632335,
     "wof:placetype":"region",

--- a/data/856/716/25/85671625.geojson
+++ b/data/856/716/25/85671625.geojson
@@ -64,11 +64,17 @@
     "name:eus_x_preferred":[
         "Saint John"
     ],
+    "name:fas_x_preferred":[
+        "\u067e\u0631\u06cc\u0634 \u0633\u0646\u062a \u062c\u0627\u0646"
+    ],
     "name:fin_x_preferred":[
         "Saint John"
     ],
     "name:fra_x_preferred":[
         "Paroisse de Saint John"
+    ],
+    "name:frr_x_preferred":[
+        "Saint John"
     ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0a82\u0a9f \u0a9c\u0acd\u0ab9\u0acb\u0aa8 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
@@ -85,11 +91,17 @@
     "name:jpn_x_preferred":[
         "\u30bb\u30f3\u30c8\u30fb\u30b8\u30e7\u30f3\u90e1"
     ],
+    "name:jpn_x_variant":[
+        "\u30bb\u30f3\u30c8\u30fb\u30b8\u30e7\u30f3\u6559\u533a"
+    ],
     "name:kan_x_preferred":[
         "\u0cb8\u0cc7\u0c82\u0c9f\u0ccd \u0c9c\u0cbe\u0ca8\u0ccd \u0caa\u0ccd\u0caf\u0cbe\u0cb0\u0cbf\u0cb7\u0ccd"
     ],
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\uc874 \uad50\uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\uc874\uad6c"
     ],
     "name:lav_x_preferred":[
         "Sentd\u017eona pagasts"
@@ -108,6 +120,9 @@
     ],
     "name:nob_x_preferred":[
         "Saint John prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint John Parish"
     ],
     "name:nor_x_preferred":[
         "Saint John prestegjeld"
@@ -285,7 +300,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500403,
+    "wof:lastmodified":1690921366,
     "wof:name":"Saint John",
     "wof:parent_id":85632335,
     "wof:placetype":"region",

--- a/data/856/716/27/85671627.geojson
+++ b/data/856/716/27/85671627.geojson
@@ -64,11 +64,17 @@
     "name:eus_x_preferred":[
         "Saint Mark"
     ],
+    "name:fas_x_preferred":[
+        "\u067e\u0627\u0631\u06cc\u0633 \u0633\u0646\u062a \u0645\u0627\u0631\u06a9"
+    ],
     "name:fin_x_preferred":[
         "Saint Mark"
     ],
     "name:fra_x_preferred":[
         "Paroisse de Saint Mark"
+    ],
+    "name:frr_x_preferred":[
+        "Saint Mark"
     ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0aae\u0abe\u0ab0\u0acd\u0a95 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
@@ -91,11 +97,17 @@
     "name:jpn_x_preferred":[
         "\u30bb\u30f3\u30c8\u30fb\u30de\u30fc\u30af"
     ],
+    "name:jpn_x_variant":[
+        "\u30bb\u30f3\u30c8\u30fb\u30de\u30fc\u30af\u6559\u533a"
+    ],
     "name:kan_x_preferred":[
         "\u0cb8\u0cc7\u0c82\u0c9f\u0ccd \u0cae\u0cbe\u0cb0\u0ccd\u0c95\u0ccd \u0caa\u0ccd\u0caf\u0cbe\u0cb0\u0cbf\u0cb7\u0ccd"
     ],
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\ub9c8\ud06c \uad50\uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\ub9c8\ud06c\uad6c"
     ],
     "name:lav_x_preferred":[
         "Sentmarka pagasts"
@@ -279,7 +291,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500403,
+    "wof:lastmodified":1690921364,
     "wof:name":"Saint Mark",
     "wof:parent_id":85632335,
     "wof:placetype":"region",

--- a/data/856/716/31/85671631.geojson
+++ b/data/856/716/31/85671631.geojson
@@ -64,11 +64,17 @@
     "name:eus_x_preferred":[
         "Saint Patrick"
     ],
+    "name:fas_x_preferred":[
+        "\u067e\u0631\u06cc\u0634 \u0633\u0646\u062a \u067e\u0627\u062a\u0631\u06cc\u06a9"
+    ],
     "name:fin_x_preferred":[
         "Saint Patrick"
     ],
     "name:fra_x_preferred":[
         "Paroisse de Saint Patrick"
+    ],
+    "name:frr_x_preferred":[
+        "Saint Patrick"
     ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0aaa\u0ac7\u0a9f\u0acd\u0ab0\u0abf\u0a95 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
@@ -91,11 +97,17 @@
     "name:jpn_x_preferred":[
         "\u30bb\u30f3\u30c8\u30fb\u30d1\u30c8\u30ea\u30c3\u30af\u90e1"
     ],
+    "name:jpn_x_variant":[
+        "\u30bb\u30f3\u30c8\u30fb\u30d1\u30c8\u30ea\u30c3\u30af\u6559\u533a"
+    ],
     "name:kan_x_preferred":[
         "\u0cb8\u0cc7\u0c82\u0c9f\u0ccd \u0caa\u0ccd\u0caf\u0cbe\u0c9f\u0ccd\u0cb0\u0cbf\u0c95\u0ccd \u0caa\u0ccd\u0caf\u0cbe\u0cb0\u0cbf\u0cb7\u0ccd"
     ],
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\ud328\ud2b8\ub9ad \uad50\uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\ud328\ud2b8\ub9ad\uad6c"
     ],
     "name:lav_x_preferred":[
         "Sentpatrika pagasts"
@@ -277,7 +289,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500403,
+    "wof:lastmodified":1690921365,
     "wof:name":"Saint Patrick",
     "wof:parent_id":85632335,
     "wof:placetype":"region",

--- a/data/890/422/095/890422095.geojson
+++ b/data/890/422/095/890422095.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ast_x_preferred":[
+        "Gouyave"
+    ],
     "name:bul_x_preferred":[
         "\u0413\u043e\u0443\u044f\u0432\u0435"
     ],
@@ -67,6 +70,9 @@
     "name:swe_x_preferred":[
         "Gouyave"
     ],
+    "name:szl_x_preferred":[
+        "Gouyave"
+    ],
     "name:und_x_variant":[
         "Goyave"
     ],
@@ -110,7 +116,7 @@
         }
     ],
     "wof:id":890422095,
-    "wof:lastmodified":1566636698,
+    "wof:lastmodified":1690921367,
     "wof:name":"Gouyave",
     "wof:parent_id":85671625,
     "wof:placetype":"locality",

--- a/data/890/439/023/890439023.geojson
+++ b/data/890/439/023/890439023.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ast_x_preferred":[
+        "Hillsborough"
+    ],
     "name:cat_x_preferred":[
         "Hillsborough"
     ],
@@ -48,6 +51,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05d4\u05d9\u05dc\u05e1\u05d1\u05d5\u05e8\u05d5"
+    ],
+    "name:ita_x_preferred":[
+        "Hillsborough"
     ],
     "name:jpn_x_preferred":[
         "\u30d2\u30eb\u30ba\u30dc\u30ed"
@@ -113,7 +119,7 @@
         }
     ],
     "wof:id":890439023,
-    "wof:lastmodified":1566636698,
+    "wof:lastmodified":1690921368,
     "wof:name":"Hillsborough",
     "wof:parent_id":85671605,
     "wof:placetype":"locality",

--- a/data/890/441/889/890441889.geojson
+++ b/data/890/441/889/890441889.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ast_x_preferred":[
+        "Grenville"
+    ],
     "name:ceb_x_preferred":[
         "Grenville"
     ],
@@ -42,6 +45,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05d2\u05e8\u05e0\u05d5\u05d5\u05d9\u05dc"
+    ],
+    "name:ind_x_preferred":[
+        "Grenville"
     ],
     "name:ita_x_preferred":[
         "Grenville"
@@ -113,7 +119,7 @@
         }
     ],
     "wof:id":890441889,
-    "wof:lastmodified":1566636698,
+    "wof:lastmodified":1690921367,
     "wof:name":"Grenville",
     "wof:parent_id":85671609,
     "wof:placetype":"locality",

--- a/data/890/451/719/890451719.geojson
+++ b/data/890/451/719/890451719.geojson
@@ -27,14 +27,32 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u0646\u062a \u062c\u0648\u0631\u062c\u0632"
     ],
+    "name:arg_x_preferred":[
+        "Saint George's"
+    ],
+    "name:ary_x_preferred":[
+        "\u0633\u0627\u0646\u062a \u062c\u0648\u0631\u062c\u0632"
+    ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0646\u062a \u062c\u0648\u0631\u062c\u0632"
+    ],
     "name:ast_x_preferred":[
+        "Saint George"
+    ],
+    "name:avk_x_preferred":[
         "Saint George"
     ],
     "name:aze_x_preferred":[
         "Sent Corces"
     ],
+    "name:ban_x_preferred":[
+        "St. George's"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0421\u0435\u043d\u0442-\u0414\u0436\u043e\u0440\u0434\u0436\u044d\u0441"
+    ],
+    "name:bel_x_variant":[
+        "\u0421\u0435\u043d\u0442-\u0414\u0436\u043e\u0440\u0434\u0436\u044d\u0441"
     ],
     "name:bod_x_preferred":[
         "\u0f66\u0f53\u0f0b\u0f50\u0f0b\u0f47\u0f7c\u0f62\u0f0b\u0f47\u0f72\u0f0d"
@@ -108,6 +126,9 @@
     "name:fra_x_preferred":[
         "Saint-Georges"
     ],
+    "name:frr_x_preferred":[
+        "St. George's"
+    ],
     "name:fry_x_preferred":[
         "Sint George's"
     ],
@@ -128,6 +149,9 @@
     ],
     "name:hat_x_preferred":[
         "Sen J\u00f2j"
+    ],
+    "name:hau_x_preferred":[
+        "St. George's"
     ],
     "name:heb_x_preferred":[
         "\u05e1\u05e0\u05d8 \u05d2'\u05d5\u05e8\u05d2'"
@@ -180,11 +204,17 @@
     "name:lav_x_preferred":[
         "Sentd\u017eord\u017eesa"
     ],
+    "name:lij_x_preferred":[
+        "St. George's"
+    ],
     "name:lit_x_preferred":[
         "Sent D\u017eord\u017eas"
     ],
     "name:lmo_x_preferred":[
         "St. George's"
+    ],
+    "name:mal_x_preferred":[
+        "\u0d38\u0d46\u0d2f\u0d4d\u0d28\u0d4d\u0d31\u0d4d \u0d1c\u0d4b\u0d7c\u0d1c\u0d4d\u0d38\u0d4d"
     ],
     "name:mar_x_preferred":[
         "\u0938\u0947\u0902\u091f \u091c\u0949\u0930\u094d\u091c\u0947\u0938"
@@ -219,11 +249,17 @@
     "name:olo_x_preferred":[
         "Sent-D\u017eord\u017ees"
     ],
+    "name:oss_x_preferred":[
+        "\u0421\u0435\u043d\u0442-\u0414\u0436\u043e\u0440\u0434\u0436\u0435\u0441"
+    ],
     "name:pan_x_preferred":[
         "\u0a38\u0a47\u0a02\u0a1f \u0a1c\u0a3e\u0a30\u0a1c"
     ],
     "name:pms_x_preferred":[
         "St. George's"
+    ],
+    "name:pnb_x_preferred":[
+        "\u0633\u06cc\u0646\u0679 \u062c\u0627\u0631\u062c\u0632"
     ],
     "name:pol_x_preferred":[
         "Saint George's"
@@ -232,7 +268,8 @@
         "Saint George.s"
     ],
     "name:por_x_variant":[
-        "Saint George's"
+        "Saint George's",
+        "S\u00e3o Jorge"
     ],
     "name:ron_x_preferred":[
         "Saint George's"
@@ -291,6 +328,9 @@
     "name:tat_x_preferred":[
         "\u0421\u0435\u043d\u0442-\u0496\u043e\u0440\u0497\u0435\u0441"
     ],
+    "name:tgk_x_preferred":[
+        "\u0421\u0435\u043d\u0442-\u04b6\u043e\u0440\u0436\u0435\u0441"
+    ],
     "name:tgl_x_preferred":[
         "St. George's"
     ],
@@ -299,6 +339,9 @@
     ],
     "name:tur_x_preferred":[
         "Saint George's"
+    ],
+    "name:udm_x_preferred":[
+        "\u0421\u0435\u043d\u0442-\u0414\u0436\u043e\u0440\u0434\u0436\u0435\u0441"
     ],
     "name:ukr_x_preferred":[
         "\u0421\u0435\u043d\u0442-\u0414\u0436\u043e\u0440\u0434\u0436\u0435\u0441"
@@ -329,6 +372,12 @@
     ],
     "name:war_x_preferred":[
         "St. George's"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5723\u4e54\u6cbb"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10e1\u10d4\u10dc\u10e2-\u10ef\u10dd\u10e0\u10ef\u10d4\u10e1\u10d8"
     ],
     "name:yor_x_preferred":[
         "St. George's"
@@ -475,7 +524,7 @@
         }
     ],
     "wof:id":890451719,
-    "wof:lastmodified":1636500405,
+    "wof:lastmodified":1690921368,
     "wof:name":"Saint George's",
     "wof:parent_id":-1,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.