### PR TITLE
gd concordances, placetype local, and more

### DIFF
--- a/data/856/323/35/85632335.geojson
+++ b/data/856/323/35/85632335.geojson
@@ -1063,6 +1063,7 @@
         "hasc:id":"GD",
         "icao:code":"J3",
         "ioc:id":"GRN",
+        "iso:code":"GD",
         "itu:id":"GRD",
         "loc:id":"n80104478",
         "m49:code":"308",
@@ -1077,6 +1078,7 @@
         "wk:page":"Grenada",
         "wmo:id":"GD"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GD",
     "wof:country_alpha3":"GRD",
     "wof:geom_alt":[
@@ -1097,7 +1099,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694639668,
+    "wof:lastmodified":1695881328,
     "wof:name":"Grenada",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/716/05/85671605.geojson
+++ b/data/856/716/05/85671605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002944,
-    "geom:area_square_m":35541431.350298,
+    "geom:area_square_m":35541787.986391,
     "geom:bbox":"-61.496246,12.440375,-61.38386,12.529731",
     "geom:latitude":12.481299,
     "geom:longitude":-61.449603,
@@ -284,11 +284,13 @@
         "gn:id":7303836,
         "gp:id":-2345478,
         "hasc:id":"GD.CA",
+        "iso:code":"GD-10",
         "iso:id":"GD-10",
         "wd:id":"Q1476309"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GD",
-    "wof:geomhash":"7f738ce6c948e5dc41fd3e60b32a641e",
+    "wof:geomhash":"9953e922a5ae8d6a4b744edea34eeb00",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -303,7 +305,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690921363,
+    "wof:lastmodified":1695884865,
     "wof:name":"Carriacou and Petite Martinique",
     "wof:parent_id":85632335,
     "wof:placetype":"region",

--- a/data/856/716/09/85671609.geojson
+++ b/data/856/716/09/85671609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006266,
-    "geom:area_square_m":75750072.192904,
+    "geom:area_square_m":75749952.120553,
     "geom:bbox":"-61.688028,12.069037,-61.603222,12.179165",
     "geom:latitude":12.128582,
     "geom:longitude":-61.642375,
@@ -281,14 +281,16 @@
         "gn:id":3579938,
         "gp:id":2345473,
         "hasc:id":"GD.AN",
+        "iso:code":"GD-01",
         "iso:id":"GD-01",
         "qs_pg:id":1142819,
         "unlc:id":"GD-01",
         "wd:id":"Q977183",
         "wk:page":"Saint Andrew Parish, Grenada"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GD",
-    "wof:geomhash":"7501c038a02b19725a8554a896c3d0fa",
+    "wof:geomhash":"d3b85857b99c0aea32c2bc1feada13cc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -303,7 +305,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690921365,
+    "wof:lastmodified":1695884865,
     "wof:name":"Saint Andrew",
     "wof:parent_id":85632335,
     "wof:placetype":"region",

--- a/data/856/716/13/85671613.geojson
+++ b/data/856/716/13/85671613.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003414,
-    "geom:area_square_m":41289335.36046,
+    "geom:area_square_m":41289180.473657,
     "geom:bbox":"-61.696253,12.02204,-61.624501,12.089511",
     "geom:latitude":12.057512,
     "geom:longitude":-61.663179,
@@ -278,14 +278,16 @@
         "gn:id":3579932,
         "gp:id":2345474,
         "hasc:id":"GD.DA",
+        "iso:code":"GD-02",
         "iso:id":"GD-02",
         "qs_pg:id":1117345,
         "unlc:id":"GD-02",
         "wd:id":"Q2087806",
         "wk:page":"Saint David Parish, Grenada"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GD",
-    "wof:geomhash":"da0aaecc0113cf0fa9b39eb7bcea6f11",
+    "wof:geomhash":"7a27c08c7318748b7eec9c923625371a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -300,7 +302,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690921365,
+    "wof:lastmodified":1695884865,
     "wof:name":"Saint David",
     "wof:parent_id":85632335,
     "wof:placetype":"region",

--- a/data/856/716/17/85671617.geojson
+++ b/data/856/716/17/85671617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00693,
-    "geom:area_square_m":83797088.296469,
+    "geom:area_square_m":83797065.26758,
     "geom:bbox":"-61.790517,12.002834,-61.676513,12.110896",
     "geom:latitude":12.056883,
     "geom:longitude":-61.724192,
@@ -290,14 +290,16 @@
         "gn:id":3579926,
         "gp:id":2345475,
         "hasc:id":"GD.GE",
+        "iso:code":"GD-03",
         "iso:id":"GD-03",
         "qs_pg:id":894888,
         "unlc:id":"GD-03",
         "wd:id":"Q576651",
         "wk:page":"Saint George Parish, Grenada"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GD",
-    "wof:geomhash":"61a117acc4c27c218b72c683ecebe31f",
+    "wof:geomhash":"c950cb34e66c28f6ad5752ee593a46fd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -312,7 +314,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690921364,
+    "wof:lastmodified":1695884865,
     "wof:name":"Saint George",
     "wof:parent_id":85632335,
     "wof:placetype":"region",

--- a/data/856/716/25/85671625.geojson
+++ b/data/856/716/25/85671625.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004027,
-    "geom:area_square_m":48679791.034515,
+    "geom:area_square_m":48679960.066279,
     "geom:bbox":"-61.751047,12.110073,-61.66253,12.183947",
     "geom:latitude":12.143566,
     "geom:longitude":-61.706204,
@@ -278,14 +278,16 @@
         "gn:id":3579919,
         "gp:id":2345476,
         "hasc:id":"GD.JO",
+        "iso:code":"GD-04",
         "iso:id":"GD-04",
         "qs_pg:id":1083828,
         "unlc:id":"GD-04",
         "wd:id":"Q1476289",
         "wk:page":"Saint John Parish, Grenada"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GD",
-    "wof:geomhash":"3ce10e0131b0b6e05ee20defef7c9d30",
+    "wof:geomhash":"4ede0c6ca0f18a8e53f858299e88ca12",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -300,7 +302,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690921366,
+    "wof:lastmodified":1695884865,
     "wof:name":"Saint John",
     "wof:parent_id":85632335,
     "wof:placetype":"region",

--- a/data/856/716/27/85671627.geojson
+++ b/data/856/716/27/85671627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001954,
-    "geom:area_square_m":23612135.278393,
+    "geom:area_square_m":23612247.916995,
     "geom:bbox":"-61.715148,12.158602,-61.65595,12.223333",
     "geom:latitude":12.191306,
     "geom:longitude":-61.679851,
@@ -269,14 +269,16 @@
         "gn:id":3579913,
         "gp:id":2345477,
         "hasc:id":"GD.MA",
+        "iso:code":"GD-05",
         "iso:id":"GD-05",
         "qs_pg:id":1083834,
         "unlc:id":"GD-05",
         "wd:id":"Q1291077",
         "wk:page":"Saint Mark Parish, Grenada"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GD",
-    "wof:geomhash":"2752ebcab0bc9f766589697c8283611d",
+    "wof:geomhash":"6fba39a2ee122bad9a4aa0cc8a360be8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -291,7 +293,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690921364,
+    "wof:lastmodified":1695884865,
     "wof:name":"Saint Mark",
     "wof:parent_id":85632335,
     "wof:placetype":"region",

--- a/data/856/716/31/85671631.geojson
+++ b/data/856/716/31/85671631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003681,
-    "geom:area_square_m":44480254.933605,
+    "geom:area_square_m":44479841.009892,
     "geom:bbox":"-61.682134,12.176691,-61.580474,12.315375",
     "geom:latitude":12.215762,
     "geom:longitude":-61.634546,
@@ -268,13 +268,15 @@
         "gn:id":3579907,
         "gp:id":2345478,
         "hasc:id":"GD.PA",
+        "iso:code":"GD-06",
         "iso:id":"GD-06",
         "qs_pg:id":1083835,
         "wd:id":"Q1476309",
         "wk:page":"Saint Patrick Parish, Grenada"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GD",
-    "wof:geomhash":"8a4e4afa81b249b21eb0271cf817d3a0",
+    "wof:geomhash":"98ceba8804039f89174dabf0db200498",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -289,7 +291,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690921365,
+    "wof:lastmodified":1695884865,
     "wof:name":"Saint Patrick",
     "wof:parent_id":85632335,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.